### PR TITLE
Feat/post select 게시글 목록 조회를 제외한 api 구현

### DIFF
--- a/src/main/java/com/sparta/topster/domain/post/controller/PostController.java
+++ b/src/main/java/com/sparta/topster/domain/post/controller/PostController.java
@@ -47,7 +47,7 @@ public class PostController {
 
         Long postId = postService.update(req, id, userDetails.getUser().getId());
         RootNoDataRes res = RootNoDataRes.builder()
-            .message(postId + "번 게시글 생성 완료하였습니다.")
+            .message(postId + "번 게시글 수정 완료하였습니다.")
             .code("201")
             .build();
         return ResponseEntity.ok(res);
@@ -60,7 +60,7 @@ public class PostController {
 
         Long deleteId = postService.delete(id, userDetails.getUser().getId());
         RootNoDataRes res = RootNoDataRes.builder()
-            .message(deleteId + "번 게시글 생성 완료하였습니다.")
+            .message(deleteId + "번 게시글 삭제 완료하였습니다.")
             .code("200")
             .build();
         return ResponseEntity.ok(res);

--- a/src/main/java/com/sparta/topster/domain/post/controller/PostController.java
+++ b/src/main/java/com/sparta/topster/domain/post/controller/PostController.java
@@ -5,12 +5,13 @@ import static org.springframework.http.HttpStatus.CREATED;
 import com.sparta.topster.domain.post.dto.request.PostCreateReq;
 import com.sparta.topster.domain.post.dto.request.PostUpdateReq;
 import com.sparta.topster.domain.post.service.PostService;
-import com.sparta.topster.global.response.RootResponseDto;
+import com.sparta.topster.global.response.RootNoDataRes;
 import com.sparta.topster.global.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,25 +27,38 @@ public class PostController {
     private final PostService postService;
 
     @PostMapping("/topster/{topsterId}/posts")
-    public ResponseEntity<?> create(@Valid @RequestBody PostCreateReq req,
+    public ResponseEntity<RootNoDataRes> create(@Valid @RequestBody PostCreateReq req,
         @PathVariable Long topsterId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
         Long postId = postService.save(req, topsterId, userDetails.getUser());
-        RootResponseDto<Object> res = RootResponseDto.builder()
+        RootNoDataRes res = RootNoDataRes.builder()
             .message(postId + "번 게시글 생성 완료하였습니다.")
             .code("201")
             .build();
         return ResponseEntity.status(CREATED).body(res);
     }
 
-    
+
     @PatchMapping("/posts/{id}")
-    public ResponseEntity<?> update(@Valid @RequestBody PostUpdateReq req,
+    public ResponseEntity<RootNoDataRes> update(@Valid @RequestBody PostUpdateReq req,
         @PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
         Long postId = postService.update(req, id, userDetails.getUser().getId());
-        RootResponseDto<Object> res = RootResponseDto.builder()
-            .message(postId + "번 게시글 수정 완료하였습니다.")
+        RootNoDataRes res = RootNoDataRes.builder()
+            .message(postId + "번 게시글 생성 완료하였습니다.")
+            .code("201")
+            .build();
+        return ResponseEntity.ok(res);
+    }
+
+
+    @DeleteMapping("/posts/{id}")
+    public ResponseEntity<RootNoDataRes> delete(@PathVariable Long id,
+        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        Long deleteId = postService.delete(id, userDetails.getUser().getId());
+        RootNoDataRes res = RootNoDataRes.builder()
+            .message(deleteId + "번 게시글 생성 완료하였습니다.")
             .code("200")
             .build();
         return ResponseEntity.ok(res);

--- a/src/main/java/com/sparta/topster/domain/post/controller/PostController.java
+++ b/src/main/java/com/sparta/topster/domain/post/controller/PostController.java
@@ -4,6 +4,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 
 import com.sparta.topster.domain.post.dto.request.PostCreateReq;
 import com.sparta.topster.domain.post.dto.request.PostUpdateReq;
+import com.sparta.topster.domain.post.dto.response.PostDeatilRes;
 import com.sparta.topster.domain.post.service.PostService;
 import com.sparta.topster.global.response.RootNoDataRes;
 import com.sparta.topster.global.security.UserDetailsImpl;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -64,4 +66,9 @@ public class PostController {
         return ResponseEntity.ok(res);
     }
 
+    @GetMapping("/posts/{id}")
+    public ResponseEntity<PostDeatilRes> getPostDetail(@PathVariable Long id) {
+        PostDeatilRes res = postService.getPostDetail(id);
+        return ResponseEntity.ok(res);
+    }
 }

--- a/src/main/java/com/sparta/topster/domain/post/controller/PostController.java
+++ b/src/main/java/com/sparta/topster/domain/post/controller/PostController.java
@@ -1,7 +1,18 @@
 package com.sparta.topster.domain.post.controller;
 
+import static org.springframework.http.HttpStatus.CREATED;
+
+import com.sparta.topster.domain.post.dto.request.PostCreateReq;
 import com.sparta.topster.domain.post.service.PostService;
+import com.sparta.topster.global.response.RootResponseDto;
+import com.sparta.topster.global.security.UserDetailsImpl;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,6 +22,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
     private final PostService postService;
+
+    @PostMapping("/topster/{topsterId}/posts")
+    public ResponseEntity<?> create(@Valid @RequestBody PostCreateReq req,
+        @PathVariable Long topsterId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        Long postId = postService.save(req, topsterId, userDetails.getUser());
+        RootResponseDto<Object> res = RootResponseDto.builder()
+            .message(postId + "번 게시글 생성 완료하였습니다.")
+            .code("200")
+            .build();
+        return ResponseEntity.status(CREATED).body(res);
+    }
 
 
 }

--- a/src/main/java/com/sparta/topster/domain/post/controller/PostController.java
+++ b/src/main/java/com/sparta/topster/domain/post/controller/PostController.java
@@ -3,6 +3,7 @@ package com.sparta.topster.domain.post.controller;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import com.sparta.topster.domain.post.dto.request.PostCreateReq;
+import com.sparta.topster.domain.post.dto.request.PostUpdateReq;
 import com.sparta.topster.domain.post.service.PostService;
 import com.sparta.topster.global.response.RootResponseDto;
 import com.sparta.topster.global.security.UserDetailsImpl;
@@ -10,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,10 +32,22 @@ public class PostController {
         Long postId = postService.save(req, topsterId, userDetails.getUser());
         RootResponseDto<Object> res = RootResponseDto.builder()
             .message(postId + "번 게시글 생성 완료하였습니다.")
-            .code("200")
+            .code("201")
             .build();
         return ResponseEntity.status(CREATED).body(res);
     }
 
+    
+    @PatchMapping("/posts/{id}")
+    public ResponseEntity<?> update(@Valid @RequestBody PostUpdateReq req,
+        @PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        Long postId = postService.update(req, id, userDetails.getUser().getId());
+        RootResponseDto<Object> res = RootResponseDto.builder()
+            .message(postId + "번 게시글 수정 완료하였습니다.")
+            .code("200")
+            .build();
+        return ResponseEntity.ok(res);
+    }
 
 }

--- a/src/main/java/com/sparta/topster/domain/post/controller/PostController.java
+++ b/src/main/java/com/sparta/topster/domain/post/controller/PostController.java
@@ -1,0 +1,16 @@
+package com.sparta.topster.domain.post.controller;
+
+import com.sparta.topster.domain.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class PostController {
+
+    private final PostService postService;
+
+
+}

--- a/src/main/java/com/sparta/topster/domain/post/dto/request/PostCreateReq.java
+++ b/src/main/java/com/sparta/topster/domain/post/dto/request/PostCreateReq.java
@@ -1,0 +1,12 @@
+package com.sparta.topster.domain.post.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+@Builder
+public record PostCreateReq(
+    @Size(min = 3, max = 50, message = "제목은 3 ~ 50자 입니다.") String title,
+    @Size(min = 10, max = 500, message = "내용은 10 ~ 500자 입니다.") String content
+) {
+
+}

--- a/src/main/java/com/sparta/topster/domain/post/dto/request/PostUpdateReq.java
+++ b/src/main/java/com/sparta/topster/domain/post/dto/request/PostUpdateReq.java
@@ -1,0 +1,10 @@
+package com.sparta.topster.domain.post.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record PostUpdateReq(
+    @Size(min = 3, max = 50, message = "제목은 3 ~ 50자 입니다.") String title,
+    @Size(min = 10, max = 500, message = "내용은 10 ~ 500자 입니다.") String content
+) {
+
+}

--- a/src/main/java/com/sparta/topster/domain/post/dto/response/PostDeatilRes.java
+++ b/src/main/java/com/sparta/topster/domain/post/dto/response/PostDeatilRes.java
@@ -1,0 +1,15 @@
+package com.sparta.topster.domain.post.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record PostDeatilRes(
+    Long id,
+    Long topsterId,
+    String title,
+    String content,
+    String nickname,
+    String createdAt
+) {
+
+}

--- a/src/main/java/com/sparta/topster/domain/post/entity/Post.java
+++ b/src/main/java/com/sparta/topster/domain/post/entity/Post.java
@@ -40,4 +40,9 @@ public class Post extends BaseEntity {
         this.user = user;
         this.topster = topster;
     }
+    
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/sparta/topster/domain/post/entity/Post.java
+++ b/src/main/java/com/sparta/topster/domain/post/entity/Post.java
@@ -1,0 +1,43 @@
+package com.sparta.topster.domain.post.entity;
+
+import com.sparta.topster.domain.BaseEntity;
+import com.sparta.topster.domain.topster.entity.Topster;
+import com.sparta.topster.domain.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Topster topster;
+
+    @Builder
+    public Post(String title, String content, User user, Topster topster) {
+        this.title = title;
+        this.content = content;
+        this.user = user;
+        this.topster = topster;
+    }
+}

--- a/src/main/java/com/sparta/topster/domain/post/exception/PostException.java
+++ b/src/main/java/com/sparta/topster/domain/post/exception/PostException.java
@@ -9,8 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PostException implements ErrorCode {
 
-    NOT_FOUND(HttpStatus.NOT_FOUND, "1001", "해당 게시글이 존재하지 않습니다."),
-    AccessDeniedError(HttpStatus.FORBIDDEN, "1002", "해당 게시글의 작성자가 아닙니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND, "P1001", "해당 게시글이 존재하지 않습니다."),
+    AccessDeniedError(HttpStatus.FORBIDDEN, "P1002", "해당 게시글의 작성자가 아닙니다.");
 
     private final HttpStatus Status;
     private final String code;

--- a/src/main/java/com/sparta/topster/domain/post/exception/PostException.java
+++ b/src/main/java/com/sparta/topster/domain/post/exception/PostException.java
@@ -1,0 +1,33 @@
+package com.sparta.topster.domain.post.exception;
+
+import com.sparta.topster.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostException implements ErrorCode {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, "1001", "해당 게시글이 존재하지 않습니다."),
+    AccessDeniedError(HttpStatus.FORBIDDEN, "1002", "해당 게시글의 작성자가 아닙니다.");
+
+    private final HttpStatus Status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.Status;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/sparta/topster/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/sparta/topster/domain/post/repository/PostRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.topster.domain.post.repository;
+
+import com.sparta.topster.domain.post.entity.Post;
+import org.springframework.data.repository.RepositoryDefinition;
+
+@RepositoryDefinition(domainClass = Post.class, idClass = Long.class)
+public interface PostRepository {
+
+    Post save(Post post);
+
+}

--- a/src/main/java/com/sparta/topster/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/sparta/topster/domain/post/repository/PostRepository.java
@@ -11,4 +11,5 @@ public interface PostRepository {
 
     Optional<Post> findById(Long id);
 
+    void delete(Post post);
 }

--- a/src/main/java/com/sparta/topster/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/sparta/topster/domain/post/repository/PostRepository.java
@@ -2,6 +2,7 @@ package com.sparta.topster.domain.post.repository;
 
 import com.sparta.topster.domain.post.entity.Post;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.RepositoryDefinition;
 
 @RepositoryDefinition(domainClass = Post.class, idClass = Long.class)
@@ -12,4 +13,7 @@ public interface PostRepository {
     Optional<Post> findById(Long id);
 
     void delete(Post post);
+
+    @Query("select p from Post p join fetch p.topster t join fetch p.user u where p.id = :id")
+    Optional<Post> findByIdFetchJoinTopsterAndUser(Long id);
 }

--- a/src/main/java/com/sparta/topster/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/sparta/topster/domain/post/repository/PostRepository.java
@@ -1,11 +1,14 @@
 package com.sparta.topster.domain.post.repository;
 
 import com.sparta.topster.domain.post.entity.Post;
+import java.util.Optional;
 import org.springframework.data.repository.RepositoryDefinition;
 
 @RepositoryDefinition(domainClass = Post.class, idClass = Long.class)
 public interface PostRepository {
 
     Post save(Post post);
+
+    Optional<Post> findById(Long id);
 
 }

--- a/src/main/java/com/sparta/topster/domain/post/service/PostService.java
+++ b/src/main/java/com/sparta/topster/domain/post/service/PostService.java
@@ -1,7 +1,11 @@
 package com.sparta.topster.domain.post.service;
 
+import com.sparta.topster.domain.post.dto.request.PostCreateReq;
+import com.sparta.topster.domain.post.entity.Post;
 import com.sparta.topster.domain.post.repository.PostRepository;
+import com.sparta.topster.domain.topster.entity.Topster;
 import com.sparta.topster.domain.topster.service.TopsterService;
+import com.sparta.topster.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,5 +16,15 @@ public class PostService {
     private final PostRepository postRepository;
     private final TopsterService topsterService;
 
+    public Long save(PostCreateReq req, Long topsterId, User user) {
+        Topster topster = topsterService.getTopster(topsterId);
+        Post post = postRepository.save(Post.builder()
+            .title(req.title())
+            .content(req.content())
+            .topster(topster)
+            .user(user)
+            .build());
+        return post.getId();
+    }
 
 }

--- a/src/main/java/com/sparta/topster/domain/post/service/PostService.java
+++ b/src/main/java/com/sparta/topster/domain/post/service/PostService.java
@@ -1,16 +1,21 @@
 package com.sparta.topster.domain.post.service;
 
 import com.sparta.topster.domain.post.dto.request.PostCreateReq;
+import com.sparta.topster.domain.post.dto.request.PostUpdateReq;
 import com.sparta.topster.domain.post.entity.Post;
+import com.sparta.topster.domain.post.exception.PostException;
 import com.sparta.topster.domain.post.repository.PostRepository;
 import com.sparta.topster.domain.topster.entity.Topster;
 import com.sparta.topster.domain.topster.service.TopsterService;
 import com.sparta.topster.domain.user.entity.User;
+import com.sparta.topster.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class PostService {
 
     private final PostRepository postRepository;
@@ -24,7 +29,30 @@ public class PostService {
             .topster(topster)
             .user(user)
             .build());
+
         return post.getId();
     }
 
+
+    public Long update(PostUpdateReq req, Long id, Long userId) {
+        Post post = getUserPost(id, userId);
+        post.update(req.title(), req.content());
+        return post.getId();
+    }
+
+
+    public Post getPost(Long id) {
+        return postRepository.findById(id).orElseThrow(() -> {
+            throw new ServiceException(PostException.NOT_FOUND);
+        });
+    }
+
+
+    private Post getUserPost(Long id, Long userId) {
+        Post post = getPost(id);
+        if (post.getUser().getId() != userId) {
+            throw new ServiceException(PostException.AccessDeniedError);
+        }
+        return post;
+    }
 }

--- a/src/main/java/com/sparta/topster/domain/post/service/PostService.java
+++ b/src/main/java/com/sparta/topster/domain/post/service/PostService.java
@@ -40,6 +40,12 @@ public class PostService {
         return post.getId();
     }
 
+    public Long delete(Long id, Long userId) {
+        Post post = getUserPost(id, userId);
+        postRepository.delete(post);
+        return id;
+    }
+
 
     public Post getPost(Long id) {
         return postRepository.findById(id).orElseThrow(() -> {

--- a/src/main/java/com/sparta/topster/domain/post/service/PostService.java
+++ b/src/main/java/com/sparta/topster/domain/post/service/PostService.java
@@ -2,6 +2,7 @@ package com.sparta.topster.domain.post.service;
 
 import com.sparta.topster.domain.post.dto.request.PostCreateReq;
 import com.sparta.topster.domain.post.dto.request.PostUpdateReq;
+import com.sparta.topster.domain.post.dto.response.PostDeatilRes;
 import com.sparta.topster.domain.post.entity.Post;
 import com.sparta.topster.domain.post.exception.PostException;
 import com.sparta.topster.domain.post.repository.PostRepository;
@@ -9,6 +10,8 @@ import com.sparta.topster.domain.topster.entity.Topster;
 import com.sparta.topster.domain.topster.service.TopsterService;
 import com.sparta.topster.domain.user.entity.User;
 import com.sparta.topster.global.exception.ServiceException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,15 +38,30 @@ public class PostService {
 
 
     public Long update(PostUpdateReq req, Long id, Long userId) {
-        Post post = getUserPost(id, userId);
+        Post post = getUserPost(getPost(id), userId);
         post.update(req.title(), req.content());
         return post.getId();
     }
 
+
     public Long delete(Long id, Long userId) {
-        Post post = getUserPost(id, userId);
+        Post post = getUserPost(getPost(id), userId);
         postRepository.delete(post);
         return id;
+    }
+
+
+    public PostDeatilRes getPostDetail(Long id) {
+        Post post = postRepository.findByIdFetchJoinTopsterAndUser(id)
+            .orElseThrow(() -> new ServiceException(PostException.NOT_FOUND));
+        return PostDeatilRes.builder()
+            .id(post.getId())
+            .title(post.getTitle())
+            .content(post.getContent())
+            .nickname(post.getUser().getNickname())
+            .topsterId(post.getTopster().getId())
+            .createdAt(dateFormat(post.getCreatedAt()))
+            .build();
     }
 
 
@@ -54,11 +72,14 @@ public class PostService {
     }
 
 
-    private Post getUserPost(Long id, Long userId) {
-        Post post = getPost(id);
+    private Post getUserPost(Post post, Long userId) {
         if (post.getUser().getId() != userId) {
             throw new ServiceException(PostException.AccessDeniedError);
         }
         return post;
+    }
+
+    private String dateFormat(LocalDateTime date) {
+        return date.format(DateTimeFormatter.ofPattern("YYYY-MM-dd HH:mm:ss"));
     }
 }

--- a/src/main/java/com/sparta/topster/domain/post/service/PostService.java
+++ b/src/main/java/com/sparta/topster/domain/post/service/PostService.java
@@ -1,0 +1,16 @@
+package com.sparta.topster.domain.post.service;
+
+import com.sparta.topster.domain.post.repository.PostRepository;
+import com.sparta.topster.domain.topster.service.TopsterService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final TopsterService topsterService;
+
+
+}

--- a/src/main/java/com/sparta/topster/global/response/RootNoDataRes.java
+++ b/src/main/java/com/sparta/topster/global/response/RootNoDataRes.java
@@ -1,0 +1,13 @@
+package com.sparta.topster.global.response;
+
+
+import lombok.Builder;
+
+@Builder
+public record RootNoDataRes(
+    String code,
+    String message
+) {
+
+}
+


### PR DESCRIPTION
## 개요
게시글 목록 조회를 제외한 api 구현

## 작업사항
- 게시글 등록 api 구현
- 게시글 수정 api 구현
- 게시글 삭제 api 구현
- 게시글 목록조회 api 구현
- data 없는 글로벌 응답 생성

## 변경로직
- 없음

## 관련 이슈
- #4 
