### PR TITLE
Feat/post select 게시글 목록 조회 구현

### DIFF
--- a/src/main/java/com/sparta/topster/domain/post/controller/PostController.java
+++ b/src/main/java/com/sparta/topster/domain/post/controller/PostController.java
@@ -3,13 +3,18 @@ package com.sparta.topster.domain.post.controller;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import com.sparta.topster.domain.post.dto.request.PostCreateReq;
+import com.sparta.topster.domain.post.dto.request.PostPageReq;
+import com.sparta.topster.domain.post.dto.request.PostSearchCond;
+import com.sparta.topster.domain.post.dto.request.PostSortReq;
 import com.sparta.topster.domain.post.dto.request.PostUpdateReq;
 import com.sparta.topster.domain.post.dto.response.PostDeatilRes;
+import com.sparta.topster.domain.post.dto.response.PostListRes;
 import com.sparta.topster.domain.post.service.PostService;
 import com.sparta.topster.global.response.RootNoDataRes;
 import com.sparta.topster.global.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -69,6 +74,14 @@ public class PostController {
     @GetMapping("/posts/{id}")
     public ResponseEntity<PostDeatilRes> getPostDetail(@PathVariable Long id) {
         PostDeatilRes res = postService.getPostDetail(id);
+        return ResponseEntity.ok(res);
+    }
+
+    @GetMapping("/posts")
+    public ResponseEntity<Page<PostListRes>> getPostList(PostSearchCond cond, PostPageReq pageReq,
+        PostSortReq sortReq) {
+
+        Page<PostListRes> res = postService.getPostList(cond, pageReq, sortReq);
         return ResponseEntity.ok(res);
     }
 }

--- a/src/main/java/com/sparta/topster/domain/post/dto/request/PostPageReq.java
+++ b/src/main/java/com/sparta/topster/domain/post/dto/request/PostPageReq.java
@@ -1,0 +1,19 @@
+package com.sparta.topster.domain.post.dto.request;
+
+import lombok.Getter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@Getter
+public class PostPageReq {
+
+    private Integer page;
+    private Integer max;
+
+    public Pageable toPageable() {
+        page = page == null ? 1 : page;
+        max = max == null ? 10 : max;
+        return PageRequest.of(page - 1, max);
+    }
+
+}

--- a/src/main/java/com/sparta/topster/domain/post/dto/request/PostSearchCond.java
+++ b/src/main/java/com/sparta/topster/domain/post/dto/request/PostSearchCond.java
@@ -1,0 +1,8 @@
+package com.sparta.topster.domain.post.dto.request;
+
+public record PostSearchCond(
+    String key,
+    String query
+) {
+
+}

--- a/src/main/java/com/sparta/topster/domain/post/dto/request/PostSortReq.java
+++ b/src/main/java/com/sparta/topster/domain/post/dto/request/PostSortReq.java
@@ -1,0 +1,15 @@
+package com.sparta.topster.domain.post.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class PostSortReq {
+
+    private String sortBy;
+    private Boolean asc;
+
+    public PostSortReq(String sortBy, Boolean asc) {
+        this.sortBy = sortBy;
+        this.asc = asc == null ? false : true;
+    }
+}

--- a/src/main/java/com/sparta/topster/domain/post/dto/response/PostListRes.java
+++ b/src/main/java/com/sparta/topster/domain/post/dto/response/PostListRes.java
@@ -1,0 +1,13 @@
+package com.sparta.topster.domain.post.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class PostListRes {
+
+    private Long id;
+    private String nickname;
+    private String title;
+    private String createdAt;
+
+}

--- a/src/main/java/com/sparta/topster/domain/post/repository/PostQueryDslRepository.java
+++ b/src/main/java/com/sparta/topster/domain/post/repository/PostQueryDslRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.topster.domain.post.repository;
+
+import com.sparta.topster.domain.post.dto.request.PostSearchCond;
+import com.sparta.topster.domain.post.dto.request.PostSortReq;
+import com.sparta.topster.domain.post.dto.response.PostListRes;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostQueryDslRepository {
+
+    Page<PostListRes> getPostList(PostSearchCond cond, Pageable pageable, PostSortReq sortReq);
+
+}

--- a/src/main/java/com/sparta/topster/domain/post/repository/PostQueryDslRepositoryImpl.java
+++ b/src/main/java/com/sparta/topster/domain/post/repository/PostQueryDslRepositoryImpl.java
@@ -1,0 +1,90 @@
+package com.sparta.topster.domain.post.repository;
+
+import static com.querydsl.core.types.Order.ASC;
+import static com.querydsl.core.types.Order.DESC;
+import static com.sparta.topster.domain.post.entity.QPost.post;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.topster.domain.post.dto.request.PostSearchCond;
+import com.sparta.topster.domain.post.dto.request.PostSortReq;
+import com.sparta.topster.domain.post.dto.response.PostListRes;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class PostQueryDslRepositoryImpl implements PostQueryDslRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<PostListRes> getPostList(PostSearchCond cond, Pageable pageable,
+        PostSortReq sortReq) {
+
+        List<PostListRes> list = jpaQueryFactory.select(
+                Projections.fields(PostListRes.class,
+                    post.id,
+                    post.user.nickname,
+                    post.title,
+                    Expressions.stringTemplate("DATE_FORMAT({0}, '%Y.%m.%d %H:%i:%s')", post.createdAt)
+                        .as("createdAt")))
+            .from(post)
+            .leftJoin(post.user)
+            .where(search(cond.key(), cond.query()))
+            .orderBy(sort(sortReq.getSortBy(), sortReq.getAsc()))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory.select(post.count())
+            .from(post)
+            .where(search(cond.key(), cond.query()));
+
+        return PageableExecutionUtils.getPage(list, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression search(String key, String query) {
+        if (!StringUtils.hasText(key)) {
+            return null;
+        }
+        switch (key) {
+            case "title":
+                return post.title.contains(query);
+            case "content":
+                return post.content.contains(query);
+            case "author":
+                return post.user.nickname.contains(query);
+            default:
+                return null;
+        }
+    }
+
+    private OrderSpecifier sort(String sortBy, boolean asc) {
+        if (!StringUtils.hasText(sortBy)) {
+            return post.createdAt.desc();
+        }
+        return getSort(sortBy, asc ? ASC : DESC);
+    }
+
+    private OrderSpecifier getSort(String sortBy, Order order) {
+        switch (sortBy) {
+            case "created":
+                return new OrderSpecifier<>(order, post.createdAt);
+            case "title":
+                return new OrderSpecifier<>(order, post.title);
+            default:
+                return new OrderSpecifier<>(DESC, post.createdAt);
+        }
+    }
+}

--- a/src/main/java/com/sparta/topster/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/sparta/topster/domain/post/repository/PostRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.RepositoryDefinition;
 
 @RepositoryDefinition(domainClass = Post.class, idClass = Long.class)
-public interface PostRepository {
+public interface PostRepository extends PostQueryDslRepository {
 
     Post save(Post post);
 

--- a/src/main/java/com/sparta/topster/domain/post/service/PostService.java
+++ b/src/main/java/com/sparta/topster/domain/post/service/PostService.java
@@ -1,8 +1,12 @@
 package com.sparta.topster.domain.post.service;
 
 import com.sparta.topster.domain.post.dto.request.PostCreateReq;
+import com.sparta.topster.domain.post.dto.request.PostPageReq;
+import com.sparta.topster.domain.post.dto.request.PostSearchCond;
+import com.sparta.topster.domain.post.dto.request.PostSortReq;
 import com.sparta.topster.domain.post.dto.request.PostUpdateReq;
 import com.sparta.topster.domain.post.dto.response.PostDeatilRes;
+import com.sparta.topster.domain.post.dto.response.PostListRes;
 import com.sparta.topster.domain.post.entity.Post;
 import com.sparta.topster.domain.post.exception.PostException;
 import com.sparta.topster.domain.post.repository.PostRepository;
@@ -13,6 +17,7 @@ import com.sparta.topster.global.exception.ServiceException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,6 +67,13 @@ public class PostService {
             .topsterId(post.getTopster().getId())
             .createdAt(dateFormat(post.getCreatedAt()))
             .build();
+    }
+
+    
+    public Page<PostListRes> getPostList(PostSearchCond cond, PostPageReq pageReq,
+        PostSortReq sortReq) {
+
+        return postRepository.getPostList(cond, pageReq.toPageable(), sortReq);
     }
 
 

--- a/src/main/java/com/sparta/topster/global/config/JpaConfig.java
+++ b/src/main/java/com/sparta/topster/global/config/JpaConfig.java
@@ -1,9 +1,18 @@
 package com.sparta.topster.global.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @Configuration
 public class JpaConfig {
+
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+
 }


### PR DESCRIPTION
## 개요
게시글 목록 조회 구현

## 작업사항
- 게시글 QuerydslRepository 추가
- 기존 Repository에서 QueryDslRepository 상속받음
- QueryDslImpl을 통해 게시글 목록 조회 구현

## 변경로직
- JpaConfig에 QueryDsl 사용을 위한 JpaQueryFactory Bean 등록

## 관련 이슈
- #4 
