### PR TITLE
Refactor/post 작성자 필드명 변경 등의 처리

### DIFF
--- a/src/main/java/com/sparta/topster/domain/post/dto/response/PostDeatilRes.java
+++ b/src/main/java/com/sparta/topster/domain/post/dto/response/PostDeatilRes.java
@@ -9,7 +9,7 @@ public record PostDeatilRes(
     Long topsterId,
     String title,
     String content,
-    String nickname,
+    String author,
     LocalDateTime createdAt
 ) {
 

--- a/src/main/java/com/sparta/topster/domain/post/dto/response/PostListRes.java
+++ b/src/main/java/com/sparta/topster/domain/post/dto/response/PostListRes.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class PostListRes {
 
     private Long id;
-    private String nickname;
+    private String author;
     private String title;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/sparta/topster/domain/post/repository/PostQueryDslRepositoryImpl.java
+++ b/src/main/java/com/sparta/topster/domain/post/repository/PostQueryDslRepositoryImpl.java
@@ -34,7 +34,7 @@ public class PostQueryDslRepositoryImpl implements PostQueryDslRepository {
         List<PostListRes> list = jpaQueryFactory.select(
                 Projections.fields(PostListRes.class,
                     post.id,
-                    post.user.nickname,
+                    post.user.nickname.as("author"),
                     post.title,
                     post.createdAt))
             .from(post)

--- a/src/main/java/com/sparta/topster/domain/post/service/PostService.java
+++ b/src/main/java/com/sparta/topster/domain/post/service/PostService.java
@@ -62,7 +62,7 @@ public class PostService {
             .id(post.getId())
             .title(post.getTitle())
             .content(post.getContent())
-            .nickname(post.getUser().getNickname())
+            .author(post.getUser().getNickname())
             .topsterId(post.getTopster().getId())
             .createdAt(post.getCreatedAt())
             .build();

--- a/src/main/java/com/sparta/topster/domain/post/service/PostService.java
+++ b/src/main/java/com/sparta/topster/domain/post/service/PostService.java
@@ -11,6 +11,7 @@ import com.sparta.topster.domain.post.entity.Post;
 import com.sparta.topster.domain.post.exception.PostException;
 import com.sparta.topster.domain.post.repository.PostRepository;
 import com.sparta.topster.domain.topster.entity.Topster;
+import com.sparta.topster.domain.topster.exception.TopsterException;
 import com.sparta.topster.domain.topster.service.TopsterService;
 import com.sparta.topster.domain.user.entity.User;
 import com.sparta.topster.global.exception.ServiceException;
@@ -28,7 +29,7 @@ public class PostService {
     private final TopsterService topsterService;
 
     public Long save(PostCreateReq req, Long topsterId, User user) {
-        Topster topster = topsterService.getTopster(topsterId);
+        Topster topster = getUserTopster(topsterId, user);
         Post post = postRepository.save(Post.builder()
             .title(req.title())
             .content(req.content())
@@ -79,6 +80,15 @@ public class PostService {
         return postRepository.findById(id).orElseThrow(() -> {
             throw new ServiceException(PostException.NOT_FOUND);
         });
+    }
+
+
+    private Topster getUserTopster(Long topsterId, User user) {
+        Topster topster = topsterService.getTopster(topsterId);
+        if (!topster.getUser().getId().equals(user.getId())) {
+            throw new ServiceException(TopsterException.NOT_AUTHOR);
+        }
+        return topster;
     }
 
 

--- a/src/main/java/com/sparta/topster/domain/user/service/mail/MailService.java
+++ b/src/main/java/com/sparta/topster/domain/user/service/mail/MailService.java
@@ -7,6 +7,7 @@ import jakarta.mail.internet.MimeMessage.RecipientType;
 import java.io.UnsupportedEncodingException;
 import java.util.Random;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
@@ -17,6 +18,9 @@ public class MailService implements MailServiceInter {
     JavaMailSender emailSender; // MailConfig에서 등록해둔 Bean을 autowired하여 사용하기
 
     private String ePw; // 사용자가 메일로 받을 인증번호
+
+    @Value("${mail.id}")
+    private String from;
 
     // 메일 내용 작성
     @Override
@@ -45,7 +49,7 @@ public class MailService implements MailServiceInter {
 
         message.setText(msgg, "utf-8", "html"); // 메일 내용, charset타입, subtype
         // 보내는 사람의 이메일 주소, 보내는 사람 이름
-        message.setFrom(new InternetAddress("asdfjk0418@naver.com", "Topster"));
+        message.setFrom(new InternetAddress(from, "Topster"));
         System.out.println("********creatMessage 함수에서 생성된 msgg 메시지********" + msgg);
 
         System.out.println("********creatMessage 함수에서 생성된 리턴 메시지********" + message);


### PR DESCRIPTION
## 개요
응답 객체 작성자 필드명 변경 외 2가지

## 작업사항
- 게시글 응답 객체 작성자 필드명 변경 nickname -> author
- 본인의 탑스터가 아닌 것으로 게시글 작성하려고 시도할 시 예외 발생
- MailService의 setFrom에서 이메일 부분을 환경변수로 설정한 이메일로 변경

## 변경로직
- MailService 부분에 필드 from 추가 및 setFrom에 추가한 from으로 변경

## 관련 이슈
- 
