### PR TITLE
TopsterService 순환 참조 해결

### DIFF
--- a/src/main/java/com/sparta/topster/domain/like/controller/LikeController.java
+++ b/src/main/java/com/sparta/topster/domain/like/controller/LikeController.java
@@ -18,20 +18,20 @@ public class LikeController {
 
     private final LikeService likeService;
 
-    @PostMapping("/{topsterId}/like")
-    public ResponseEntity<?> toggleLike(@PathVariable Long topsterId,
-                                        @AuthenticationPrincipal UserDetailsImpl userDetails) {
-
-        try {
-            boolean liked = likeService.toggleLike(topsterId, userDetails);
-
-            if(liked) {
-                return ResponseEntity.ok().body(new RootNoDataRes("200", "좋아요"));
-            } else {
-                return ResponseEntity.ok().body(new RootNoDataRes("200", "좋아요 취소"));
-            }
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().body(new RootNoDataRes(e.getMessage(), "400"));
-        }
-    }
+//    @PostMapping("/{topsterId}/like")
+//    public ResponseEntity<?> toggleLike(@PathVariable Long topsterId,
+//                                        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+//
+//        try {
+//            boolean liked = likeService.toggleLike(topsterId, userDetails);
+//
+//            if(liked) {
+//                return ResponseEntity.ok().body(new RootNoDataRes("200", "좋아요"));
+//            } else {
+//                return ResponseEntity.ok().body(new RootNoDataRes("200", "좋아요 취소"));
+//            }
+//        } catch (Exception e) {
+//            return ResponseEntity.badRequest().body(new RootNoDataRes(e.getMessage(), "400"));
+//        }
+//    }
 }

--- a/src/main/java/com/sparta/topster/domain/like/entity/Like.java
+++ b/src/main/java/com/sparta/topster/domain/like/entity/Like.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -34,9 +35,10 @@ public class Like extends BaseEntity{
     private Topster topster;
 
 
-    public Like(Topster topster, UserDetailsImpl userDetails) {
+    @Builder
+    public Like(Topster topster, User user) {
         this.topster = topster;
-        this.user = userDetails.getUser();
+        this.user = user;
     }
 
 

--- a/src/main/java/com/sparta/topster/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/sparta/topster/domain/like/repository/LikeRepository.java
@@ -16,5 +16,6 @@ public interface LikeRepository {
   void save(Like like);
 
   Optional<Like> findByTopsterIdAndUserId(Long topsterId, Long userId);
+  boolean existsByTopsterIdAndUserId(Long topsterId, Long userId);
 
 }

--- a/src/main/java/com/sparta/topster/domain/like/service/LikeService.java
+++ b/src/main/java/com/sparta/topster/domain/like/service/LikeService.java
@@ -18,35 +18,34 @@ import org.springframework.transaction.annotation.Transactional;
 public class LikeService {
 
     private final LikeRepository likeRepository;
-    private final TopsterService topsterService;
-
-  @Transactional
-  public boolean toggleLike(Long topsterId, UserDetailsImpl userDetails) {
-    // 해당 id의 탑스터가 존재하는지 검증
-    Topster topster = topsterService.getTopster(topsterId);
-
-    // 현재 사용자의 좋아요 상태 조회
-    Like optionalLike = getLike(userDetails.getUser().getId(), topsterId);
-
-    log.info("조회된 좋아요 목록을 순회");
-      // 현재 사용자가 이미 해당 게시물에 좋아요를 눌렀는지 확인
-      if(optionalLike != null) {
-        // 이미 좋아요를 눌렀다면 해당 좋아요 삭제
-        likeRepository.delete(optionalLike);
-        // 좋아요 수 감소
-        topster.upAndDownLikeCount(-1);
-        return false;
-      }
-     log.info("좋아요 누르지 않았다면 실행");
-    // likeCount + 1
-    topster.upAndDownLikeCount(1);
-    // 해당 탑스타와 사용자 정보를 가지고 있는 좋아요 객체 생성
-    Like like = new Like(topster, userDetails);
-    // 좋아요 정보를 데이터베이스에 저장
-    likeRepository.save(like);
-
-    return true;
-  }
+//    private final TopsterService topsterService;
+//
+//  @Transactional
+//  public boolean toggleLike(Long topsterId, UserDetailsImpl userDetails) {
+//    // 해당 id의 탑스터가 존재하는지 검증
+//    Topster topster = topsterService.getTopster(topsterId);
+//
+//    // 해당 탑스타에 대한 모든 좋아요 정보를 조회
+//    Like optionalLike = getLike(userDetails.getUser().getId(), topsterId);
+//
+//    log.info("조회된 좋아요 목록을 순회");
+//      // 현재 사용자가 이미 해당 게시물에 좋아요를 눌렀는지 확인
+//      if(optionalLike != null) {
+//        // 이미 좋아요를 눌렀다면 해당 좋아요 삭제
+//        likeRepository.delete(optionalLike);
+//        topster.upAndDownLikeCount(-1);
+//        return false;
+//      }
+//     log.info("좋아요 누르지 않았다면 실행");
+//    // likeCount + 1
+//    topster.upAndDownLikeCount(1);
+//    // 해당 탑스타와 사용자 정보를 가지고 있는 좋아요 객체 생성
+//    Like like = new Like(topster, userDetails);
+//    // 사용자가 아직 좋아요를 누르지 않았다면 좋아요 정보 추가
+//    likeRepository.save(like);
+//
+//    return true;
+//  }
 
   public Like getLike(Long userId, Long topsterId) {
     Optional<Like> optionalLike = likeRepository.findByTopsterIdAndUserId(topsterId, userId);
@@ -56,6 +55,12 @@ public class LikeService {
       log.info("해당 유저가 탑스터에 좋아요를 누르지 않았습니다.");
     }
     return null;
+  }
+
+
+  public void deleteLike(Like like){
+    log.info("like 삭제");
+    likeRepository.delete(like);
   }
 
 }

--- a/src/main/java/com/sparta/topster/domain/open_api/service/maniadb/ManiadbService.java
+++ b/src/main/java/com/sparta/topster/domain/open_api/service/maniadb/ManiadbService.java
@@ -40,7 +40,7 @@ public class ManiadbService implements OpenApiService {
         URI uri = UriComponentsBuilder.fromUriString("http://www.maniadb.com")
                 .path("api/search/" + query + "/")
                 .queryParam("sr", "album")
-                .queryParam("display", 10)
+                .queryParam("display", 20)
                 .queryParam("v", 0.5)
                 .encode()
                 .build()

--- a/src/main/java/com/sparta/topster/domain/topster/controller/TopsterController.java
+++ b/src/main/java/com/sparta/topster/domain/topster/controller/TopsterController.java
@@ -55,7 +55,7 @@ public class TopsterController {
     }
 
 
-    @GetMapping("/topsters/{topsterId}/like")
+    @PostMapping("/topsters/{topsterId}/like")
     public ResponseEntity<?> toggleLike(@PathVariable Long topsterId,
                                         @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return ResponseEntity.ok(topsterService.toggleTopsterLike(topsterId, userDetails.getUser()));

--- a/src/main/java/com/sparta/topster/domain/topster/controller/TopsterController.java
+++ b/src/main/java/com/sparta/topster/domain/topster/controller/TopsterController.java
@@ -55,4 +55,11 @@ public class TopsterController {
     }
 
 
+    @GetMapping("/topsters/{topsterId}/like")
+    public ResponseEntity<?> toggleLike(@PathVariable Long topsterId,
+                                        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok(topsterService.toggleTopsterLike(topsterId, userDetails.getUser()));
+    }
+
+
 }

--- a/src/main/java/com/sparta/topster/domain/topster/dto/res/TopsterCreateLoginRes.java
+++ b/src/main/java/com/sparta/topster/domain/topster/dto/res/TopsterCreateLoginRes.java
@@ -8,21 +8,25 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-public class TopsterCreateRes {
+public class TopsterCreateLoginRes {
     Long id;
     String title;
     String content;
     String author;
+    Long likeCount;
+    Boolean likeStatus;
     LocalDateTime createdAt;
     List<AlbumRes> albums;
 
     @Builder
-    public TopsterCreateRes(Long id, String title, String content, String author, LocalDateTime createdAt, List<AlbumRes> albums) {
+    public TopsterCreateLoginRes(Long id, String title, String content, String author, LocalDateTime createdAt, List<AlbumRes> albums) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.author = author;
         this.createdAt = createdAt;
         this.albums = albums;
+        this.likeCount =0L;
+        this.likeStatus = false;
     }
 }

--- a/src/main/java/com/sparta/topster/domain/topster/dto/res/TopsterGetLoginRes.java
+++ b/src/main/java/com/sparta/topster/domain/topster/dto/res/TopsterGetLoginRes.java
@@ -9,11 +9,13 @@ import java.util.List;
 
 @Getter
 @Builder
-public class TopsterGetRes {
+public class TopsterGetLoginRes {
     Long id;
     String title;
     String author;
     String content;
+    Long likeCount;
+    Boolean likeStatus;
     List<AlbumRes> albums;
     LocalDateTime createdAt;
 }

--- a/src/main/java/com/sparta/topster/domain/topster/dto/res/TopsterGetNotLoginRes.java
+++ b/src/main/java/com/sparta/topster/domain/topster/dto/res/TopsterGetNotLoginRes.java
@@ -1,0 +1,20 @@
+package com.sparta.topster.domain.topster.dto.res;
+
+import com.sparta.topster.domain.album.dto.res.AlbumRes;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class TopsterGetNotLoginRes {
+    Long id;
+    String title;
+    String author;
+    String content;
+    Long likeCount;
+    List<AlbumRes> albums;
+    LocalDateTime createdAt;
+}

--- a/src/main/java/com/sparta/topster/domain/topster/entity/Topster.java
+++ b/src/main/java/com/sparta/topster/domain/topster/entity/Topster.java
@@ -4,6 +4,7 @@ package com.sparta.topster.domain.topster.entity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sparta.topster.domain.BaseEntity;
+import com.sparta.topster.domain.like.entity.Like;
 import com.sparta.topster.domain.topster_album.entity.TopsterAlbum;
 import com.sparta.topster.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -31,6 +32,8 @@ public class Topster extends BaseEntity {
     @Column
     private String content;
 
+    @OneToMany(mappedBy = "topster", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    List<Like> topsterLike = new ArrayList<>();
 
     @OneToMany(mappedBy = "topster", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     List<TopsterAlbum> topsterAlbumList = new ArrayList<>();

--- a/src/main/java/com/sparta/topster/domain/topster/service/TopsterService.java
+++ b/src/main/java/com/sparta/topster/domain/topster/service/TopsterService.java
@@ -7,8 +7,8 @@ import com.sparta.topster.domain.album.service.AlbumService;
 import com.sparta.topster.domain.like.entity.Like;
 import com.sparta.topster.domain.like.service.LikeService;
 import com.sparta.topster.domain.topster.dto.req.TopsterCreateReq;
-import com.sparta.topster.domain.topster.dto.res.TopsterCreateRes;
-import com.sparta.topster.domain.topster.dto.res.TopsterGetRes;
+import com.sparta.topster.domain.topster.dto.res.TopsterCreateLoginRes;
+import com.sparta.topster.domain.topster.dto.res.TopsterGetLoginRes;
 import com.sparta.topster.domain.topster.entity.Topster;
 import com.sparta.topster.domain.topster.repository.TopsterRepository;
 import com.sparta.topster.domain.topster_album.entity.TopsterAlbum;
@@ -19,7 +19,6 @@ import com.sparta.topster.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,7 +39,7 @@ public class TopsterService {
     private final LikeService likeService;
 
     @Transactional
-    public TopsterCreateRes createTopster(TopsterCreateReq topsterCreateReq, User user) {
+    public TopsterCreateLoginRes createTopster(TopsterCreateReq topsterCreateReq, User user) {
         log.info("Topster 등록 시작");
         List<AlbumInsertReq> albumInsertReqList = topsterCreateReq.getAlbums();
         String title = topsterCreateReq.getTitle();
@@ -74,7 +73,7 @@ public class TopsterService {
             }
         log.info("Topster AlbumLlist에 Album추가 완료");
         List<AlbumRes> albumResList  = new ArrayList<>();
-        log.info("Topster Entity -> TopsterCreateRes");
+        log.info("Topster Entity -> TopsterCreateLoginRes");
         for(TopsterAlbum topsterAlbum : topster.getTopsterAlbumList()){
             albumResList.add(
                     AlbumRes.builder().
@@ -84,7 +83,7 @@ public class TopsterService {
                             release(topsterAlbum.getAlbum().getReleaseDate()).
                             build());
         }
-        return TopsterCreateRes.builder().
+        return TopsterCreateLoginRes.builder().
                 id(topster.getId()).
                 title(topster.getTitle()).
                 content(topster.getContent()).
@@ -95,24 +94,17 @@ public class TopsterService {
     }
 
 
-    public TopsterGetRes getTopsterService(Long topsterId){
-        // null이면 그냥 예외 처리할텐데?
-        Long userId;
-        if(loginUser().getUser() == null){
-            userId =0L;
-        }else {
-            userId = loginUser().getUser().getId();
-        }
+    public TopsterGetLoginRes getTopsterService(Long topsterId){
         Topster topster = getTopster(topsterId);
-        return fromTopsterToTopsterGetRes(topster, userId);
+        return fromTopsterToTopsterGetNotLoginRes(topster);
     }
 
 
     public Object getTopsterByUserService(Long userId) {
         List<Topster> topsterList = getTopsterByUser(userId);
-        List<TopsterGetRes> topsterGetResList = new ArrayList<>();
+        List<TopsterGetLoginRes> topsterGetResList = new ArrayList<>();
         for(Topster topster:topsterList){
-            topsterGetResList.add(fromTopsterToTopsterGetRes(topster, userId));
+            topsterGetResList.add(fromTopsterToTopsterGetLoginRes(topster, userId));
         }
         return topsterGetResList;
     }
@@ -135,14 +127,14 @@ public class TopsterService {
         Like like = likeService.getLike(user.getId(), topsterId);
         if(like == null){
             log.info("탑스터에 좋아요가 눌리지 않은 상태");
-            topster.getTopsterLike().add(new Like(topster, loginUser()));
+            topster.getTopsterLike().add(Like.builder().user(user).topster(topster).build());
             topster.upAndDownLikeCount(1);
         }else {
             log.info("탑스터에 좋아요가 눌린 상태");
             likeService.deleteLike(like);
             topster.upAndDownLikeCount(-1);
         }
-        return fromTopsterToTopsterGetRes(topster, loginUser().getUser().getId());
+        return fromTopsterToTopsterGetLoginRes(topster, user.getId());
     }
 
 
@@ -171,8 +163,8 @@ public class TopsterService {
     }
 
 
-    private TopsterGetRes fromTopsterToTopsterGetRes(Topster topstesr, Long userId){
-        log.info("Topster Entity -> TopsterGetRes");
+    private TopsterGetLoginRes fromTopsterToTopsterGetLoginRes(Topster topstesr, Long userId){
+        log.info("Topster Entity -> TopsterGetLoginRes");
         List<AlbumRes> albumResList = new ArrayList<>();
         for(TopsterAlbum topsterAlbum : topstesr.getTopsterAlbumList()){
             albumResList.add(
@@ -184,7 +176,7 @@ public class TopsterService {
                     .image(topsterAlbum.getAlbum().getImage()).build());
         }
 
-        return TopsterGetRes.builder()
+        return TopsterGetLoginRes.builder()
                 .id(topstesr.getId())
                 .title(topstesr.getTitle())
                 .content(topstesr.getContent())
@@ -196,17 +188,36 @@ public class TopsterService {
                 .build();
     }
 
+    private TopsterGetLoginRes fromTopsterToTopsterGetNotLoginRes(Topster topstesr){
+        log.info("Topster Entity -> TopsterGetNotLoginRes");
+        List<AlbumRes> albumResList = new ArrayList<>();
+        for(TopsterAlbum topsterAlbum : topstesr.getTopsterAlbumList()){
+            albumResList.add(
+                    AlbumRes.builder()
+                            .id(topsterAlbum.getAlbum().getId())
+                            .title(topsterAlbum.getAlbum().getTitle())
+                            .artist(topsterAlbum.getAlbum().getArtist())
+                            .release(topsterAlbum.getAlbum().getReleaseDate())
+                            .image(topsterAlbum.getAlbum().getImage()).build());
+        }
+
+        return TopsterGetLoginRes.builder()
+                .id(topstesr.getId())
+                .title(topstesr.getTitle())
+                .content(topstesr.getContent())
+                .albums(albumResList)
+                .author(topstesr.getUser().getNickname())
+                .likeCount(topstesr.getLikeCount())
+                .createdAt(topstesr.getCreatedAt())
+                .build();
+    }
+
 
     private boolean checkAuthor(Long userId, Long topsterId){
         Topster topster = getTopster(topsterId);
         return topster.getUser().getId().equals((userId));
     }
 
-
-    public UserDetailsImpl loginUser() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return (UserDetailsImpl) authentication.getPrincipal();
-    }
 
 
     public boolean isLikePresent(Long userId, Long topsterId){


### PR DESCRIPTION
## 개요
TopsterService 순환 참조 해결
로그인 유저와 비로그인 유저를 구분하도록 하기 위한 setup을 했습니다.(ResponseDto 구분)
Like를 Builder로 생성합니다. 생성 인자를 UserDetailsImpl-> User로 변경했습니다.

## 작업사항
TopsterService 순환 참조 해결
LikeService에서는 getLike와 deleteLike를 남겨놨습니다.
튜터님의 말씀 대로 종속 Entity도메인에서 상위 Entity 도메인을 찾는것을 뺐습니다.
로그인 유저와 비로그인 유저를 구분하도록 하기 위한 setup을 했습니다.(ResponseDto 구분)
Like를 Builder로 생성합니다. 생성 인자를 UserDetailsImpl-> User로 변경했습니다.

## 변경로직
Like를 TopsterService에서 생성하고 save합니다.
Like를 누를 시 TopsterGetRes를 응답합니다.

## 관련 이슈
- 
