### PR TITLE
#5 FIX. SPOTIFY CLIENT ID, SECRET 환경변수에서 value값을 집어넣는 시점 변경을 위한 생성자 추가

### DIFF
--- a/src/main/java/com/sparta/topster/domain/open_api/service/spotify/SpotifyUtil.java
+++ b/src/main/java/com/sparta/topster/domain/open_api/service/spotify/SpotifyUtil.java
@@ -1,6 +1,7 @@
 package com.sparta.topster.domain.open_api.service.spotify;
 
 import com.neovisionaries.i18n.CountryCode;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,27 +20,32 @@ import java.text.ParseException;
 
 @Slf4j(topic = "SpotifyUtil")
 @Configuration
+@RequiredArgsConstructor
 public class SpotifyUtil {
 
-    @Value("${spotify.client.id}")
     private String CLIENT_ID;
-    @Value("${spotify.client.secret}")
     private String CLIENT_SECRET;
-
+    private SpotifyApi spotifyApi;
     private URI redirecURI = UriComponentsBuilder.fromUriString("http://localhost:8080")
             .path("/users/login")
             .encode()
             .build()
             .toUri();
-    private SpotifyApi spotifyApi = new SpotifyApi.Builder()
-            .setClientId(CLIENT_ID)
-            .setClientSecret(CLIENT_SECRET)
-            .setRedirectUri(redirecURI)
-            .build();
 
-
+    public SpotifyUtil(@Value("${spotify.client.id}") String CLIENT_ID, @Value("${spotify.client.secret}") String CLIENT_SECRET) {
+        spotifyApi = new SpotifyApi.Builder()
+                .setClientId(CLIENT_ID)
+                .setClientSecret(CLIENT_SECRET)
+                .setRedirectUri(redirecURI)
+                .build();
+        this.CLIENT_ID = CLIENT_ID;
+        this.CLIENT_SECRET = CLIENT_SECRET;
+    }
 
     public String accesstoken() {
+        log.info(CLIENT_ID);
+        log.info(CLIENT_SECRET);
+
         ClientCredentialsRequest clientCredentialsRequest = spotifyApi.clientCredentials().build();
         try {
             final ClientCredentials clientCredentials = clientCredentialsRequest.execute();

--- a/src/main/java/com/sparta/topster/domain/open_api/service/spotify/SpotifyUtil.java
+++ b/src/main/java/com/sparta/topster/domain/open_api/service/spotify/SpotifyUtil.java
@@ -3,6 +3,7 @@ package com.sparta.topster.domain.open_api.service.spotify;
 import com.neovisionaries.i18n.CountryCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -20,7 +21,6 @@ import java.text.ParseException;
 
 @Slf4j(topic = "SpotifyUtil")
 @Configuration
-@RequiredArgsConstructor
 public class SpotifyUtil {
 
     private String CLIENT_ID;
@@ -31,7 +31,7 @@ public class SpotifyUtil {
             .encode()
             .build()
             .toUri();
-
+    
     public SpotifyUtil(@Value("${spotify.client.id}") String CLIENT_ID, @Value("${spotify.client.secret}") String CLIENT_SECRET) {
         spotifyApi = new SpotifyApi.Builder()
                 .setClientId(CLIENT_ID)


### PR DESCRIPTION
## 개요
#5 FIX. SPOTIFY CLIENT ID, SECRET 환경변수에서 value값을 집어넣는 시점 변경을 위한 생성자 추가

## 작업사항
- 내용을 적어주세요.

## 변경로직
SpotifyUtil 생성자 추가

## 관련 이슈
환경변수가 value값을 넣어주는 시점을 생성 시점으로 변경
