### PR TITLE
Fix/spotify/accesstoken

### DIFF
--- a/src/main/java/com/sparta/topster/TopsterApplication.java
+++ b/src/main/java/com/sparta/topster/TopsterApplication.java
@@ -1,10 +1,13 @@
 package com.sparta.topster;
 
+import com.sparta.topster.global.config.ScheduledConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.context.annotation.Import;
 
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class) // Spring Security 인증 기능 제외
+@Import(ScheduledConfig.class)
 public class TopsterApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/sparta/topster/domain/openApi/service/maniadb/ManiadbService.java
+++ b/src/main/java/com/sparta/topster/domain/openApi/service/maniadb/ManiadbService.java
@@ -14,6 +14,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.XML;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -29,7 +30,7 @@ import static com.sparta.topster.domain.openApi.exception.ManiadbException.NOT_S
 
 @Service
 @Qualifier("maniadb")
-@Slf4j(topic = "ManiaServiceImpl")
+@Slf4j(topic = "ManiaDbService")
 @RequiredArgsConstructor
 public class ManiadbService implements OpenApiService {
 

--- a/src/main/java/com/sparta/topster/domain/openApi/service/spotify/SpotifyService.java
+++ b/src/main/java/com/sparta/topster/domain/openApi/service/spotify/SpotifyService.java
@@ -29,19 +29,20 @@ public class SpotifyService implements OpenApiService {
     private final SpotifyUtil spotifyUtil;
 
     private String accessToken;
-    @PostConstruct
-    private void init(){
-        accessToken =spotifyUtil.accesstoken();
-    }
-
-    @Scheduled(cron = "* 55 * * * *")
-    public void getAccessToken() {
-        accessToken =  spotifyUtil.accesstoken();
-    }
+//    @PostConstruct
+//    private void init(){
+//        accessToken =spotifyUtil.accesstoken();
+//    }
+//
+//    @Scheduled(cron = "* 55 * * * *")
+//    public void getAccessToken() {
+//        accessToken =  spotifyUtil.accesstoken();
+//    }
 
 
     @Override
     public String getRawArtistData(String query) {
+        accessToken = spotifyUtil.accesstoken();
         log.info(query + "로 rawData 가져오기");
         RestTemplate rest = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/sparta/topster/domain/openApi/service/spotify/SpotifyService.java
+++ b/src/main/java/com/sparta/topster/domain/openApi/service/spotify/SpotifyService.java
@@ -27,17 +27,17 @@ import static com.sparta.topster.domain.openApi.exception.ManiadbException.NOT_S
 @RequiredArgsConstructor
 public class SpotifyService implements OpenApiService {
     private final SpotifyUtil spotifyUtil;
-
     private String accessToken;
-//    @PostConstruct
-//    private void init(){
-//        accessToken =spotifyUtil.accesstoken();
-//    }
-//
-//    @Scheduled(cron = "* 55 * * * *")
-//    public void getAccessToken() {
-//        accessToken =  spotifyUtil.accesstoken();
-//    }
+    @PostConstruct
+
+    private void init(){
+        accessToken = spotifyUtil.accesstoken();
+    }
+
+    @Scheduled(fixedDelay = 60 * 55 * 1000L)
+    public void getAccessToken() {
+        accessToken =  spotifyUtil.accesstoken();
+    }
 
 
     @Override
@@ -54,21 +54,22 @@ public class SpotifyService implements OpenApiService {
         HttpEntity<String> requestEntity = new HttpEntity<String>(body, headers);
         ResponseEntity<String> responseEntity = rest
                 .exchange("https://api.spotify.com/v1/search?type=album&q="
-                        + query, HttpMethod.GET, requestEntity, String.class);
+                        + query + "&limit=30", HttpMethod.GET, requestEntity, String.class);
         return responseEntity.getBody();
     }
+
 
     @Override
     public List<AlbumRes> getAlbums(String query) {
         String rawData = getRawArtistData(query);
         JSONObject rawJSONData = new JSONObject(rawData);
         log.info("rawData에서 item을 추출");
-//        if(rawJSONData.getJSONObject("albums").getBigInteger("total").equals(0)){
-            JSONArray jsonArray = rawJSONData.getJSONObject("albums").getJSONArray("items");
-            return fromJSONArrayToAlbum(jsonArray, query);
-//        }
-//        log.error(NOT_SERCH_ALBUM.getMessage());
-//        throw new ServiceException(NOT_SERCH_ALBUM);
+        if(rawJSONData.getJSONObject("albums").getJSONArray("items").isEmpty()){
+            log.error(NOT_SERCH_ALBUM.getMessage());
+            throw new ServiceException(NOT_SERCH_ALBUM);
+        }
+        JSONArray jsonArray = rawJSONData.getJSONObject("albums").getJSONArray("items");
+        return fromJSONArrayToAlbum(jsonArray, query);
     }
 
     private List<AlbumRes> fromJSONArrayToAlbum(JSONArray items, String query){
@@ -78,12 +79,12 @@ public class SpotifyService implements OpenApiService {
 
             // 가수를 검색했을 때 제목에 가수가 포함된 것도 포함됨.
             // 따라서 albumartists가 query를 포함한 것만 필터링
-            // maniadb에서 대문자/소문자를 구분하기 때문에 첫글자를 대문자로 변환하는 메소드 사용
 
             JSONArray artistArray = itemObj.getJSONArray("artists");
             String artistName = artistArray.getJSONObject(0).getString("name");
             log.info("artistName is " + artistName);
             if(query.matches("^[a-zA-Z]*$")){
+                //
                 if(artistName.contains(initialUpperCase(query))) {
                     log.info("쿼리문이 영어로 이루어져 있을 때");
                     AlbumRes album = fromJSONtoAlbumRes(itemObj, artistName);

--- a/src/main/java/com/sparta/topster/domain/openApi/service/spotify/SpotifyUtil.java
+++ b/src/main/java/com/sparta/topster/domain/openApi/service/spotify/SpotifyUtil.java
@@ -50,7 +50,7 @@ public class SpotifyUtil {
             // Set access token for further "spotifyApi" object usage
             spotifyApi.setAccessToken(clientCredentials.getAccessToken());
             String accessToken = spotifyApi.getAccessToken();
-            log.debug("Spotify accessToken is " + accessToken);
+            log.info("Spotify accessToken is " + accessToken);
             return accessToken;
 
         } catch (IOException | SpotifyWebApiException e) {


### PR DESCRIPTION
## 개요
Spotify Access Token 55분에 한번씩 갱신(PostConstruct로 빈 생성시 발급)
Spotify 앨범 검색 안될 시 예외반환
SPotify 앨범 검색량 20-> 30

## 작업사항
Spotify Access Token 55분에 한번씩 갱신(PostConstruct로 빈 생성시 발급)
Spotify 앨범 검색 안될 시 예외반환
SPotify 앨범 검색량 20-> 30

## 변경로직
스포티 파이 API 사용마다 Access Token 발급 -> 스케줄러를 이용해 Access Token을 55분에 한번씩 발급 받음

## 관련 이슈
- 
