### PR TITLE
fix: 카카오 로그인 access token 헤더로 전달, refreshToken 발급, 리다이렉트 설정

### DIFF
--- a/src/main/java/com/sparta/topster/domain/user/controller/KakaoController.java
+++ b/src/main/java/com/sparta/topster/domain/user/controller/KakaoController.java
@@ -2,10 +2,15 @@ package com.sparta.topster.domain.user.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.sparta.topster.domain.user.service.kakao.KakaoService;
+import com.sparta.topster.global.response.RootNoDataRes;
 import com.sparta.topster.global.util.JwtUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,14 +24,11 @@ public class KakaoController {
    private final KakaoService kakaoService;
 
     @GetMapping("/kakao/callback")
-    public String kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
-        String token = kakaoService.kakaoLogin(code);
+    public ResponseEntity<?> kakaoLogin(@RequestParam String code) throws JsonProcessingException {
+        HttpHeaders headers = kakaoService.kakaoLogin(code);
+        headers.setLocation(URI.create("/"));
 
-        Cookie cookie = new Cookie(JwtUtil.AUTHORIZATION_HEADER,token.substring(7));
-        cookie.setPath("/");
-        response.addCookie(cookie);
-
-        return "redirect:/";
+        return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).headers(headers).build();
     }
 
 }

--- a/src/main/java/com/sparta/topster/domain/user/service/kakao/KakaoService.java
+++ b/src/main/java/com/sparta/topster/domain/user/service/kakao/KakaoService.java
@@ -41,7 +41,7 @@ public class KakaoService {
     @Value("${kakao.secret}")
     private String secret;
 
-    public String kakaoLogin(String code) throws JsonProcessingException {
+    public HttpHeaders kakaoLogin(String code) throws JsonProcessingException {
         // 1. "인가 코드"로 "액세스 토큰" 요청
         String accessToken = getToken(code);
 
@@ -53,9 +53,14 @@ public class KakaoService {
 
         // 4. JWT 토큰 생성
         String createToken = jwtUtil.createToken(kakaoUser.getUsername(), kakaoUser.getRole());
+        String refreshToken = jwtUtil.createRefreshToken(kakaoUser.getUsername());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(JwtUtil.AUTHORIZATION_HEADER, createToken);
+        headers.add(JwtUtil.REFRESH_TOKEN_PREFIX, refreshToken);
 
         // 생성 토큰 반환
-        return createToken;
+        return headers;
     }
 
     private String getToken(String code) throws JsonProcessingException {


### PR DESCRIPTION
## 개요
카카오 로그인 access token 헤더로 전달, refreshToken 발급, 리다이렉트 설정

## 작업사항
- 내용을 적어주세요.

## 변경로직
- 내용을 적어주세요.

## 관련 이슈
- 
